### PR TITLE
Fix condition conversion to NOT LIKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ res = checkEquality()
 
 ### Changelog
 
+
+##### V 0.2.7
+- Normalize String unequality: ...<>..., ...!=..., ...NOT LIKE... --> NOT...LIKE...
+
 ##### V 0.2.6
 - Fixed bug in checkKeywords: if keyword was present in one query and not in the other, the comparison was not performed correctly.
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='sql_testing_tools',
-    version='0.2.6',
+    version='0.2.7',
     packages=find_packages(),
     install_requires=[
         'sqlparse>=0.5.1',

--- a/sql_testing_tools/TokenProcessing.py
+++ b/sql_testing_tools/TokenProcessing.py
@@ -145,6 +145,8 @@ def _condition(token, alias_map, baseDict: dict):
 
     if operator.value in ("!=", "<>"):
         return f"NOT {left} LIKE {right}"
+    if operator.value in ("NOT LIKE"):
+        return f"NOT {left} LIKE {right}"
 
     if flipAllowed and left.lower() >= right.lower():
         left, right = right, left

--- a/sql_testing_tools/TokenProcessing.py
+++ b/sql_testing_tools/TokenProcessing.py
@@ -143,6 +143,9 @@ def _condition(token, alias_map, baseDict: dict):
     left = _identifier(left, alias_map, baseDict)
     right = _identifier(right, alias_map, baseDict)
 
+    if operator.value in ("!=", "<>"):
+        return f"NOT {left} LIKE {right}"
+
     if flipAllowed and left.lower() >= right.lower():
         left, right = right, left
         if operator.value == ">":

--- a/sql_testing_tools/tests/NormalizeQuery_test.py
+++ b/sql_testing_tools/tests/NormalizeQuery_test.py
@@ -175,3 +175,11 @@ class NormalizeQuery_test(unittest.TestCase):
 
         if res == "":
             self.fail("Different grouping not recognized")
+
+    def test_a23_not_equal(self):
+        nr = '23'
+        self.helperEqual(nr)
+
+    def test_a24_not_equal(self):
+        nr = '24'
+        self.helperEqual(nr)

--- a/sql_testing_tools/tests/v1/a23.sql
+++ b/sql_testing_tools/tests/v1/a23.sql
@@ -1,0 +1,3 @@
+SELECT name, einwohner_m, einwohner_w 
+FROM Gemeinde 
+WHERE name != 'München'

--- a/sql_testing_tools/tests/v1/a24.sql
+++ b/sql_testing_tools/tests/v1/a24.sql
@@ -1,0 +1,3 @@
+SELECT name, einwohner_m, einwohner_w 
+FROM Gemeinde 
+WHERE name <> 'München'

--- a/sql_testing_tools/tests/v2/a23.sql
+++ b/sql_testing_tools/tests/v2/a23.sql
@@ -1,0 +1,3 @@
+SELECT name, einwohner_m, einwohner_w 
+FROM Gemeinde 
+WHERE NOT name LIKE 'München'

--- a/sql_testing_tools/tests/v2/a24.sql
+++ b/sql_testing_tools/tests/v2/a24.sql
@@ -1,0 +1,3 @@
+SELECT name, einwohner_m, einwohner_w 
+FROM Gemeinde 
+WHERE name NOT LIKE 'München'


### PR DESCRIPTION
Fixes #21

Update `sql_testing_tools/TokenProcessing.py` to convert `!=` and `<>` to `NOT LIKE`.

* Modify `_condition` function to include logic for converting `!=` and `<>` to `NOT LIKE`.
* Add test cases in `sql_testing_tools/tests/NormalizeQuery_test.py` for `!=` and `<>` to `NOT LIKE` conversion.
* Add SQL files `a23.sql` and `a24.sql` in `sql_testing_tools/tests/v1/` and `sql_testing_tools/tests/v2/` for testing the new conversion logic.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ValentinHerrmann/sql_testing_tools/pull/22?shareId=9397f4d7-2e9e-4aad-90af-253c4e684f0f).