### PR TITLE
Normalizes COUNT(column) to COUNT(*) for equivalence

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ res = checkEquality()
 ##### V 0.2.12
 - fixed bug when having only one colum selected
 - fixed bug with nested conditions 
+- fixed memory problem with huge cross products (used to lead to build failed)
 
 ##### V 0.2.11
 - fixed irrelevant equality order if both sides aren't literals

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ res = checkEquality()
 
 ### Changelog
 
+##### V 0.2.13
+- Acccept `COUNT(colname)`, too (instead of just `COUNT(*)`)
+
 ##### V 0.2.12
 - fixed bug when having only one colum selected
 - fixed bug with nested conditions 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='sql_testing_tools',
-    version='0.2.12',
+    version='0.2.13',
     packages=find_packages(),
     install_requires=[
         'sqlparse>=0.5.1',

--- a/sql_testing_tools/TokenProcessing.py
+++ b/sql_testing_tools/TokenProcessing.py
@@ -46,12 +46,16 @@ def _select(select, alias_map, base_dict: dict, insideFunction=False):
             else:
                 select_tokens.append(f"{_identifier(token, alias_map,  base_dict).lower()} as {token.get_real_name().lower()}")
         elif isinstance(token, Function):
-            #select_tokens.append(f"{token.get_name().lower()}({_identifier(token.get_parameters(), alias_map, base_dict).lower()})")
+            is_count = False
             for par in token.tokens:
                 if isinstance(par, Identifier):
                     select_tokens.append(par.get_name().lower()+"(")
+                    is_count = par.get_name().lower() == "count"
                 if isinstance(par, Parenthesis):
-                    select_tokens[-1] += _select(par, alias_map, base_dict, True)+") as funcResult" 
+                    select_ident = _select(par, alias_map, base_dict, True)
+                    if is_count and not any(tok.value.upper() == "DISTINCT" for tok in par.tokens):
+                        select_ident = "*"
+                    select_tokens[-1] += select_ident +") as funcResult" 
         elif token.ttype is Wildcard:
             select_tokens.append("*")
         else:

--- a/sql_testing_tools/tests/NormalizeQuery_test.py
+++ b/sql_testing_tools/tests/NormalizeQuery_test.py
@@ -331,3 +331,11 @@ class NormalizeQueryTest(unittest.TestCase):
             msg += "V2: "+He.sol + "\n"
             msg += ("-------------------------------------\n")
             self.fail(msg)
+            
+    def test_a34_count(self):
+        nr = '34'
+        self.helperEqual(nr)
+        
+    def test_a35_count_unequal(self):
+        nr = '35'
+        self.helperUnequal(nr)

--- a/sql_testing_tools/tests/v1/a34.sql
+++ b/sql_testing_tools/tests/v1/a34.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) 
+FROM Gemeinde

--- a/sql_testing_tools/tests/v1/a35.sql
+++ b/sql_testing_tools/tests/v1/a35.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(*) 
+FROM Gemeinde

--- a/sql_testing_tools/tests/v2/a34.sql
+++ b/sql_testing_tools/tests/v2/a34.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(schluessel) 
+FROM Gemeinde

--- a/sql_testing_tools/tests/v2/a35.sql
+++ b/sql_testing_tools/tests/v2/a35.sql
@@ -1,0 +1,2 @@
+SELECT COUNT(DISTINCT kreis) 
+FROM Gemeinde


### PR DESCRIPTION
## Changes

Improves SQL query comparison by treating `COUNT(column)` as equivalent to `COUNT(*)` when no `DISTINCT` modifier is present.

## Motivation

SQL queries with `COUNT(*)` and `COUNT(column)` produce semantically identical results when the column is non-nullable or when nulls don't affect the count logic. This change allows the testing tool to recognize these queries as equivalent, reducing false negatives in query comparison tests.

## Implementation

- Detects `COUNT` functions during token processing
- Automatically converts `COUNT(column)` to `COUNT(*)` for normalization
- Preserves `COUNT(DISTINCT column)` as-is since it has different semantics
- Adds test cases to verify equal and unequal COUNT scenarios

## Version

Bumps package version to 0.2.13

Closes #31 